### PR TITLE
Fix Next.js build errors in API routes and components

### DIFF
--- a/app/api/classify/route.ts
+++ b/app/api/classify/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import OpenAI from 'openai'
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-})
-
 export async function POST(request: NextRequest) {
   try {
+    // Instantiate OpenAI client at request time to avoid build-time errors
+    const openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+
     const { imageUrl } = await request.json()
 
     if (!imageUrl) {

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -2,3 +2,8 @@
 
 import * as React from "react"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
+import type { ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}


### PR DESCRIPTION
- Move OpenAI client instantiation to request time in /api/classify This prevents "Missing credentials" error during Next.js build-time page data collection when OPENAI_API_KEY is not available

- Complete ThemeProvider component implementation Add missing export and proper TypeScript types to fix build errors