### PR TITLE
Fix Vercel build output directory configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
Add vercel.json to explicitly specify Next.js framework detection. This resolves the "No Output Directory named 'dist' found" error by ensuring Vercel recognizes this as a Next.js project and uses the correct .next output directory.