### PR TITLE
docs: add Vercel deployment runbook and update .env.example with Stripe/Airtable vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,18 @@
 # Site Configuration
-# For production, set this to your website URL (e.g., https://your-domain.vercel.app)
-# For local development, use http://localhost:3000
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# For production, set this to your deployed Vercel URL
+NEXT_PUBLIC_SITE_URL=https://your-project.vercel.app
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
+
+# Stripe
+STRIPE_SECRET_KEY=sk_live_or_test_key
+STRIPE_WEBHOOK_SECRET=whsec_from_stripe_webhook_endpoint
+
+# Airtable
+AIRTABLE_API_KEY=pat_or_api_key
+AIRTABLE_BASE_ID=appXXXXXXXXXXXXXX

--- a/docs/vercel-stripe-airtable-runbook.md
+++ b/docs/vercel-stripe-airtable-runbook.md
@@ -1,0 +1,89 @@
+# Vercel + Stripe Webhook + Airtable Runbook
+
+This runbook covers importing `Z-kie/AuthiChain` into Vercel, setting the required 8 environment variables, deploying, and validating the 4 Stripe webhook events that write to Airtable.
+
+## Required environment variables (8)
+
+Set these in **Vercel → Project → Settings → Environment Variables**:
+
+1. `NEXT_PUBLIC_SITE_URL`
+2. `NEXT_PUBLIC_SUPABASE_URL`
+3. `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+4. `OPENAI_API_KEY`
+5. `STRIPE_SECRET_KEY`
+6. `STRIPE_WEBHOOK_SECRET`
+7. `AIRTABLE_API_KEY`
+8. `AIRTABLE_BASE_ID`
+
+> These are the env vars used by the codebase (`process.env.*`).
+
+## Import and deploy on Vercel
+
+1. Open: `https://vercel.com/new`
+2. Import repository: `https://github.com/Z-kie/AuthiChain`
+3. Set all 8 env vars above for Production/Preview (as needed).
+4. Click **Deploy**.
+5. Monitor build logs in **Deployments** until status is **Ready**.
+
+## Stripe webhook endpoint URL
+
+After deployment, determine your final domain:
+
+- `https://<your-vercel-domain>/api/stripe/webhook`
+
+In Stripe Dashboard:
+
+1. Developers → Webhooks → your endpoint.
+2. If domain changed, update endpoint URL.
+3. Ensure these 4 events are selected:
+   - `checkout.session.completed`
+   - `invoice.paid`
+   - `invoice.payment_failed`
+   - `customer.subscription.deleted`
+4. Copy signing secret into `STRIPE_WEBHOOK_SECRET` in Vercel if rotated.
+
+## End-to-end event test flow
+
+Use Stripe CLI (or Dashboard test events) to send all four events to production endpoint.
+
+### Option A — Stripe CLI
+
+```bash
+stripe listen --forward-to https://<your-vercel-domain>/api/stripe/webhook
+```
+
+In another terminal:
+
+```bash
+stripe trigger checkout.session.completed
+stripe trigger invoice.paid
+stripe trigger invoice.payment_failed
+stripe trigger customer.subscription.deleted
+```
+
+### Option B — Stripe Dashboard
+
+Send test webhook for each event type from Webhooks → endpoint → **Send test webhook**.
+
+## Verify Airtable writes
+
+Confirm records are created/updated in these tables:
+
+- `Events Log` (all events logged, idempotency key is Stripe Event ID)
+- `Accounts` (upsert by Stripe Customer ID)
+- `Contacts` (upsert by Email)
+- `Invoices` (created for checkout/invoice events)
+- `Revenue Projections` (upsert by Stripe Subscription ID)
+
+Recommended checks:
+
+1. For each of the 4 events, verify one `Events Log` row with `Status=success`.
+2. Verify no duplicates when replaying an event (idempotency behavior).
+3. Verify `invoice.payment_failed` marks account/projection as at risk.
+4. Verify `customer.subscription.deleted` sets MRR/ARR to 0 and status to churned.
+
+## Troubleshooting
+
+- **400 Invalid signature**: `STRIPE_WEBHOOK_SECRET` mismatch.
+- **500 Handler failed**: inspect Vercel function logs and Airtable permissions/field names.
+- **Airtable write errors**: ensure table and field names exactly match code expectations.


### PR DESCRIPTION
### Motivation

- Provide a single operational runbook for importing the repo into Vercel, setting the environment variables the code expects, deploying, and validating Stripe→Airtable webhook flows. 
- Make the exact environment variables required by the application explicit in `.env.example` so deployers know which 8 keys to configure. 

### Description

- Updated `.env.example` to list the eight environment variables used by the app (`NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `OPENAI_API_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`).
- Added `docs/vercel-stripe-airtable-runbook.md` containing step-by-step instructions for importing `Z-kie/AuthiChain` into Vercel, setting the 8 env vars, deploying, updating the Stripe webhook URL if the Vercel domain changes, testing the four Stripe events, and verifying Airtable writes.
- No runtime logic or API handlers were modified; this change is documentation and configuration-template only.

### Testing

- Ran `rg -n "process.env\.[A-Z0-9_]+" -o app lib middleware.ts | sed 's/.*process.env.//' | sort -u` to enumerate env vars referenced in code, and the output matched the 8 variables documented (succeeded).
- Executed automated Playwright scripts to open `https://vercel.com/new` and submit the repository URL, which navigated to the import URL and produced screenshots of the Vercel import flow (navigation succeeded; further deploy steps require an authenticated Vercel session and were not executed here).
- Attempted `npx vercel --version`, which failed due to an environment/npm access error (npm 403); and `npm run lint` which was blocked by an interactive ESLint setup prompt in this non-interactive environment (these checks did not complete successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20a716f40832dae74a06f003de991)