### PR TITLE
fix: restore complete mapVerificationResponse — unblocks Vercel builds

### DIFF
--- a/lib/verification.ts
+++ b/lib/verification.ts
@@ -28,7 +28,6 @@ export function normalizeProductIdentifier(value: string): string {
 export function buildVerifyPayload(rawInput: string): VerifyPayload {
   const raw = rawInput.trim()
 
-  // URL: extract ?id= param first, then fall back to path segment
   if (isLikelyUrl(raw)) {
     try {
       const parsed = new URL(raw)
@@ -42,7 +41,6 @@ export function buildVerifyPayload(rawInput: string): VerifyPayload {
     return { qrCode: raw }
   }
 
-  // PROD-* or TM-* identifiers (product IDs and TrueMark IDs)
   if (
     /^PROD-/i.test(raw) ||
     /^TM-/i.test(raw) ||
@@ -51,7 +49,6 @@ export function buildVerifyPayload(rawInput: string): VerifyPayload {
     return { productIdentifier: normalizeProductIdentifier(raw) }
   }
 
-  // Numeric token ID
   if (/^\d+$/.test(raw)) {
     return { tokenId: Number(raw) }
   }
@@ -66,7 +63,6 @@ function deriveInputIdentifier(input: string): string {
   }
   try {
     const parsed = new URL(trimmed)
-    // Prefer ?id= query param — this is the canonical QRON QR code format
     const idParam = parsed.searchParams.get('id')
     if (idParam) {
       return normalizeProductIdentifier(idParam)
@@ -81,7 +77,7 @@ function deriveInputIdentifier(input: string): string {
 
 export type VerificationViewModel = {
   result: 'authentic' | 'counterfeit'
-  authentic: Boolean
+  authentic: boolean
   trust_score: number
   confidence: 'High' | 'Medium' | 'Low'
   qron_id: string
@@ -96,4 +92,26 @@ export type VerificationViewModel = {
 }
 
 export function mapVerificationResponse(data: VerifyApiResponse, input: string): VerificationViewModel {
-  const authentic = data?.success
+  const authentic = data?.success === true && data?.product?.isActive !== false
+  const trustScore = authentic ? 96 : data?.success === true ? 30 : 10
+  const confidence: 'High' | 'Medium' | 'Low' =
+    trustScore >= 80 ? 'High' : trustScore >= 40 ? 'Medium' : 'Low'
+
+  return {
+    result: authentic ? 'authentic' : 'counterfeit',
+    authentic,
+    trust_score: trustScore,
+    confidence,
+    qron_id: data?.product?.productIdentifier || deriveInputIdentifier(input),
+    actions: authentic
+      ? ['launch_ar', 'view_story', 'claim_ownership']
+      : ['retry_scan', 'contact_support'],
+    product: data?.product ?? null,
+    supplyChain: data?.supplyChain ?? null,
+    tokenId: typeof data?.tokenId === 'number' ? data.tokenId : null,
+    success: Boolean(data?.success),
+    message: data?.message || (authentic ? 'Verified' : 'Verification failed'),
+    verifiedAt: new Date().toISOString(),
+    input,
+  }
+}


### PR DESCRIPTION
All 3 recent Vercel builds failing with syntax error in lib/verification.ts (Expected }, got eof at line 96). Restored complete mapVerificationResponse function body. Merge to restore live demo.