### PR TITLE
feat: integrate Claude artifacts + fix pre-existing TS/build errors

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -105,3 +105,20 @@ jobs:
       - name: Deploy
         run: npx wrangler deploy --compatibility-date 2024-01-01
         continue-on-error: true
+
+  deploy-authichain-automation:
+    name: Deploy authichain-automation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/authichain-automation
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Wrangler
+        run: npm install --no-save wrangler || npm install -g wrangler
+      - name: Deploy
+        run: npx wrangler deploy
+        continue-on-error: true

--- a/app/agent-browser/page.tsx
+++ b/app/agent-browser/page.tsx
@@ -39,7 +39,7 @@ function AgentBrowserInner() {
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
 
   useEffect(() => {
-    const planParam = searchParams.get('plan')
+    const planParam = searchParams?.get('plan')
     if (planParam === 'pro' || planParam === 'enterprise') {
       setPlan(planParam)
     }

--- a/app/api/characters/generate/route.ts
+++ b/app/api/characters/generate/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { buildOpenArtPrompt } from '@/packages/characters/src/prompt';
+import { OpenArtClient } from '@/packages/openart/src/client';
+
+function scoreVariant(index: number) {
+  const seeded = [
+    { protocol: 9.2, thumb: 8.8, premium: 9.1, silhouette: 9.0, trust: 9.4, mint: 9.0, ui: 8.9 },
+    { protocol: 8.7, thumb: 9.1, premium: 8.8, silhouette: 9.3, trust: 8.9, mint: 8.6, ui: 9.2 },
+    { protocol: 8.9, thumb: 8.5, premium: 9.4, silhouette: 8.6, trust: 9.0, mint: 9.3, ui: 8.7 },
+    { protocol: 8.4, thumb: 8.9, premium: 8.7, silhouette: 8.8, trust: 8.8, mint: 8.5, ui: 9.0 }
+  ];
+  return seeded[index] ?? seeded[0];
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const body = await req.json();
+  const { tenant_id, user_id, object_id, archetype, colorway, mood, object_context, brand_context, style } = body;
+
+  if (!archetype) {
+    return NextResponse.json({ error: 'archetype is required' }, { status: 400 });
+  }
+
+  const { prompt, negativePrompt } = buildOpenArtPrompt({
+    archetype,
+    colorway,
+    mood,
+    objectContext: object_context,
+    brandContext: brand_context,
+    style
+  });
+
+  const { data: generation, error: genError } = await supabase
+    .from('character_generations')
+    .insert({
+      tenant_id,
+      user_id,
+      object_id,
+      archetype,
+      style: style ?? 'premium futuristic heraldic concept art',
+      colorway,
+      mood,
+      prompt,
+      negative_prompt: negativePrompt,
+      provider: 'openart',
+      provider_model: process.env.OPENART_MODEL ?? 'openart-default',
+      status: 'pending',
+      variant_count: 4,
+      request_payload: body
+    })
+    .select('*')
+    .single();
+
+  if (genError || !generation) {
+    return NextResponse.json({ error: genError?.message ?? 'failed to create generation' }, { status: 500 });
+  }
+
+  try {
+    const client = new OpenArtClient(process.env.OPENART_API_KEY!, process.env.OPENART_BASE_URL);
+    const generated = await client.generate({
+      prompt,
+      negativePrompt,
+      numImages: 4,
+      size: '1024x1536',
+      transparentBackground: false,
+      model: process.env.OPENART_MODEL
+    });
+
+    const assetsPayload = generated.assets.map((asset, index) => {
+      const s = scoreVariant(index);
+      return {
+        generation_id: generation.id,
+        tenant_id,
+        user_id,
+        provider_asset_id: asset.id,
+        image_url: asset.imageUrl,
+        preview_url: asset.previewUrl,
+        prompt,
+        metadata: asset.metadata ?? {},
+        protocol_fit_score: s.protocol,
+        thumbnail_clarity_score: s.thumb,
+        premium_feel_score: s.premium,
+        silhouette_score: s.silhouette,
+        trust_symbolism_score: s.trust,
+        mint_readiness_score: s.mint,
+        ui_compatibility_score: s.ui
+      };
+    });
+
+    const { data: insertedAssets, error: assetError } = await supabase
+      .from('character_assets')
+      .insert(assetsPayload)
+      .select('*');
+
+    if (assetError || !insertedAssets) throw assetError ?? new Error('asset insert failed');
+
+    const recommended = [...insertedAssets].sort((a, b) => Number(b.total_score) - Number(a.total_score))[0];
+
+    await supabase.from('character_assets').update({ recommended: true }).eq('id', recommended.id);
+    await supabase
+      .from('character_generations')
+      .update({
+        status: 'completed',
+        response_payload: generated.raw,
+        best_asset_id: recommended.id
+      })
+      .eq('id', generation.id);
+
+    return NextResponse.json({
+      generation_id: generation.id,
+      best_asset_id: recommended.id,
+      assets: insertedAssets.map((a) => ({ ...a, recommended: a.id === recommended.id }))
+    });
+  } catch (error: any) {
+    await supabase
+      .from('character_generations')
+      .update({ status: 'failed', response_payload: { error: error?.message ?? 'unknown error' } })
+      .eq('id', generation.id);
+
+    return NextResponse.json({ error: error?.message ?? 'generation failed' }, { status: 500 });
+  }
+}

--- a/app/api/characters/select/route.ts
+++ b/app/api/characters/select/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const body = await req.json();
+  const { generation_id, asset_id } = body;
+
+  if (!generation_id || !asset_id) {
+    return NextResponse.json({ error: 'generation_id and asset_id are required' }, { status: 400 });
+  }
+
+  const { data: asset, error: assetError } = await supabase
+    .from('character_assets')
+    .select('*')
+    .eq('id', asset_id)
+    .eq('generation_id', generation_id)
+    .single();
+
+  if (assetError || !asset) {
+    return NextResponse.json({ error: 'asset not found for generation' }, { status: 404 });
+  }
+
+  await supabase.from('character_assets').update({ selected: false }).eq('generation_id', generation_id);
+  await supabase
+    .from('character_assets')
+    .update({ selected: true, selected_at: new Date().toISOString() })
+    .eq('id', asset_id);
+
+  const { error: genUpdateError } = await supabase
+    .from('character_generations')
+    .update({ status: 'selected', selected_asset_id: asset_id })
+    .eq('id', generation_id);
+
+  if (genUpdateError) {
+    return NextResponse.json({ error: genUpdateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    generation_id,
+    selected_asset_id: asset_id,
+    status: 'selected'
+  });
+}

--- a/app/api/checkout/qron-stake/route.ts
+++ b/app/api/checkout/qron-stake/route.ts
@@ -19,14 +19,14 @@ import { createClient as createServerClient } from '@/lib/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export const QRON_STAKE_BUNDLES = {
+const QRON_STAKE_BUNDLES = {
   bronze:   { qron_amount: 1_000,       price_usd_cents: 4900,   label: '1,000 QRON — Bronze Tier' },
   silver:   { qron_amount: 10_000,      price_usd_cents: 34900,  label: '10,000 QRON — Silver Tier' },
   gold:     { qron_amount: 100_000,     price_usd_cents: 249900, label: '100,000 QRON — Gold Tier' },
   platinum: { qron_amount: 1_000_000,   price_usd_cents: 1499900, label: '1,000,000 QRON — Platinum Tier' },
 } as const
 
-export type StakingBundle = keyof typeof QRON_STAKE_BUNDLES
+type StakingBundle = keyof typeof QRON_STAKE_BUNDLES
 
 export async function POST(req: NextRequest) {
   const stripeKey = process.env.STRIPE_SECRET_KEY

--- a/app/api/nft/metadata/[truemarkId]/route.ts
+++ b/app/api/nft/metadata/[truemarkId]/route.ts
@@ -10,9 +10,9 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { truemarkId: string } }
+  { params }: { params: Promise<{ truemarkId: string }> }
 ) {
-  const { truemarkId } = params
+  const { truemarkId } = await params
 
   const supabase = createServiceClient()
   const { data: product } = await supabase

--- a/app/api/products/[id]/route.ts
+++ b/app/api/products/[id]/route.ts
@@ -4,8 +4,9 @@ import { normalizeProductRecord } from '@/lib/contracts/products'
 
 export async function GET(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const supabase = await createClient()
 
@@ -21,7 +22,7 @@ export async function GET(
     const { data: product, error } = await supabase
       .from('products')
       .select('*')
-      .eq('id', params.id)
+      .eq('id', id)
       .eq('user_id', user.id)
       .single()
 

--- a/app/api/qron/generate/route.ts
+++ b/app/api/qron/generate/route.ts
@@ -1,0 +1,269 @@
+/**
+ * app/api/qron/generate/route.ts
+ *
+ * Full generation pipeline:
+ *   1. Auth via Supabase session
+ *   2. Credit check / deduction
+ *   3. Call fal-ai/illusion-diffusion directly via @fal-ai/client
+ *   4. Fire /api/qron/register (Supabase row + AuthiChain D1 cross-reg)
+ *   5. Return imageUrl + registration IDs
+ *
+ * Replaces the Supabase Edge Function proxy — fal.ai is called server-side
+ * so FAL_KEY never touches the client.
+ */
+
+import { NextResponse } from "next/server";
+import { fal } from "@fal-ai/client";
+import { createClient } from "@/utils/supabase/server";
+import { createClient as createAdmin } from "@supabase/supabase-js";
+import crypto from "crypto";
+
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+// ─── fal.ai client config ────────────────────────────────────────────────────
+fal.config({ credentials: process.env.FAL_KEY! });
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface GenerateBody {
+  url?: string;
+  prompt?: string;
+  presetId?: string;
+  mode?: string;
+  negative_prompt?: string;
+  guidance_scale?: number;
+  controlnet_conditioning_scale?: number;
+  num_inference_steps?: number;
+  scheduler?: "Euler" | "DPM++ Karras SDE";
+  image_size?: "square_hd" | "square" | "portrait_4_3" | "portrait_16_9" | "landscape_4_3" | "landscape_16_9";
+  seed?: number;
+  image_url?: string;
+}
+
+interface FalOutput {
+  image: { url: string; width: number; height: number; content_type: string };
+  seed: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function adminClient() {
+  return createAdmin(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+function sha256(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+function qrPatternUrl(payloadUrl: string): string {
+  const encoded = encodeURIComponent(payloadUrl);
+  return `https://api.qrserver.com/v1/create-qr-code/?size=512x512&ecc=H&data=${encoded}`;
+}
+
+// ─── Credit check ─────────────────────────────────────────────────────────────
+
+async function checkAndDeductCredit(userId: string): Promise<boolean> {
+  const admin = adminClient();
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("credits, plan")
+    .eq("id", userId)
+    .single();
+
+  if (!profile) return false;
+  if (profile.plan === "business") return true;
+  if ((profile.credits ?? 0) < 1) return false;
+
+  const { error } = await admin
+    .from("profiles")
+    .update({ credits: profile.credits - 1 })
+    .eq("id", userId);
+
+  return !error;
+}
+
+// ─── Registration ─────────────────────────────────────────────────────────────
+
+async function registerQron(params: {
+  userId: string;
+  assetUrl: string;
+  payloadUrl: string;
+  prompt: string;
+  seed: number;
+}): Promise<{ id: string | null; authichain_record_id: string | null }> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ?? "https://www.authichain.com";
+  const payloadHash = sha256(params.payloadUrl);
+
+  try {
+    const res = await fetch(`${baseUrl}/api/qron/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.AUTHICHAIN_API_SECRET}`,
+      },
+      body: JSON.stringify({
+        user_id: params.userId,
+        asset_url: params.assetUrl,
+        payload_hash: payloadHash,
+        payload_preview: params.payloadUrl.slice(0, 100),
+        prompt: params.prompt,
+        seed: params.seed,
+        chain: "polygon",
+        status: "pending_mint",
+        registered_at: new Date().toISOString(),
+        source: "qron-generate-direct",
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      console.warn("[qron/generate] register returned", res.status);
+      return { id: null, authichain_record_id: null };
+    }
+
+    const data = (await res.json()) as {
+      id?: string;
+      authichain_record_id?: string;
+    };
+    return {
+      id: data.id ?? null,
+      authichain_record_id: data.authichain_record_id ?? null,
+    };
+  } catch (err) {
+    console.warn("[qron/generate] register unreachable:", err);
+    return { id: null, authichain_record_id: null };
+  }
+}
+
+// ─── POST handler ─────────────────────────────────────────────────────────────
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  let body: GenerateBody = {};
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payloadUrl = body.url?.trim();
+  const prompt = body.prompt?.trim();
+
+  if (!payloadUrl) {
+    return NextResponse.json(
+      { error: "url (QR payload) is required" },
+      { status: 400 }
+    );
+  }
+  if (!prompt && !body.presetId) {
+    return NextResponse.json(
+      { error: "prompt or presetId is required" },
+      { status: 400 }
+    );
+  }
+
+  const hasCredit = await checkAndDeductCredit(userId);
+  if (!hasCredit) {
+    return NextResponse.json(
+      {
+        error: "Credit limit reached. Upgrade your plan to continue.",
+        code: "LIMIT_REACHED",
+      },
+      { status: 403 }
+    );
+  }
+
+  const imageUrl = body.image_url ?? qrPatternUrl(payloadUrl);
+
+  let falResult: FalOutput;
+  try {
+    const result = await fal.subscribe("fal-ai/illusion-diffusion", {
+      input: {
+        image_url: imageUrl,
+        prompt: prompt ?? "(masterpiece:1.4), (best quality), (detailed), vibrant living art QR portal",
+        negative_prompt:
+          body.negative_prompt ??
+          "(worst quality, poor details:1.4), lowres, watermark, signature",
+        guidance_scale: body.guidance_scale ?? 7.5,
+        controlnet_conditioning_scale:
+          body.controlnet_conditioning_scale ?? 1.0,
+        control_guidance_start: 0,
+        control_guidance_end: 1,
+        scheduler: body.scheduler ?? "Euler",
+        num_inference_steps: body.num_inference_steps ?? 40,
+        image_size: body.image_size ?? "square_hd",
+        ...(body.seed !== undefined && { seed: body.seed }),
+      },
+      logs: false,
+    });
+
+    falResult = result.data as FalOutput;
+  } catch (err) {
+    console.error("[qron/generate] fal.ai error:", err);
+    try {
+      const admin = adminClient();
+      const { data: p } = await admin
+        .from("profiles")
+        .select("credits")
+        .eq("id", userId)
+        .single();
+      if (p) await admin.from("profiles").update({ credits: p.credits + 1 }).eq("id", userId);
+    } catch { /* best-effort refund */ }
+
+    return NextResponse.json(
+      { error: "Image generation failed. Credit has been refunded." },
+      { status: 500 }
+    );
+  }
+
+  const generatedImageUrl = falResult.image.url;
+  const seed = falResult.seed;
+
+  const registration = await registerQron({
+    userId,
+    assetUrl: generatedImageUrl,
+    payloadUrl,
+    prompt: prompt ?? "",
+    seed,
+  });
+
+  return NextResponse.json({
+    imageUrl: generatedImageUrl,
+    qrDataUrl: generatedImageUrl,
+    prompt,
+    url: payloadUrl,
+    seed,
+    registration_id: registration.id,
+    authichain_record_id: registration.authichain_record_id,
+    qron: {
+      imageUrl: generatedImageUrl,
+      destinationUrl: payloadUrl,
+      prompt,
+      seed,
+      registration_id: registration.id,
+      authichain_record_id: registration.authichain_record_id,
+    },
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    backend: "fal-ai/illusion-diffusion",
+    model: "fal-ai/illusion-diffusion",
+    version: "direct-v2",
+  });
+}

--- a/app/api/qron/register/route.ts
+++ b/app/api/qron/register/route.ts
@@ -1,0 +1,105 @@
+/**
+ * app/api/qron/register/route.ts
+ *
+ * Receives QRON generation data and writes provenance records to Supabase.
+ * Also forwards to the AuthiChain D1 worker for cross-registration.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export const dynamic = "force-dynamic";
+
+function adminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+export async function POST(request: Request) {
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+
+  if (!token || token !== process.env.AUTHICHAIN_API_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.asset_url || !body.payload_hash) {
+    return NextResponse.json(
+      { error: "asset_url and payload_hash are required" },
+      { status: 400 }
+    );
+  }
+
+  const admin = adminClient();
+
+  // Write to Supabase qron_registrations table
+  const { data, error } = await admin
+    .from("qron_registrations")
+    .insert({
+      user_id: body.user_id as string | null,
+      asset_url: body.asset_url as string,
+      payload_hash: body.payload_hash as string,
+      payload_preview: (body.payload_preview as string) ?? null,
+      prompt: (body.prompt as string) ?? null,
+      seed: (body.seed as number) ?? null,
+      chain: (body.chain as string) ?? "polygon",
+      status: (body.status as string) ?? "pending_mint",
+      source: (body.source as string) ?? "unknown",
+      registered_at: (body.registered_at as string) ?? new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("[qron/register] Supabase insert error:", error);
+    return NextResponse.json(
+      { error: "Database write failed", detail: error.message },
+      { status: 500 }
+    );
+  }
+
+  // Forward to AuthiChain D1 worker (non-fatal)
+  let authichainRecordId: string | null = null;
+  const workerUrl = process.env.AUTHICHAIN_WORKER_URL;
+  if (workerUrl) {
+    try {
+      const res = await fetch(`${workerUrl}/api/qron-register`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.AUTHICHAIN_API_SECRET}`,
+        },
+        body: JSON.stringify({
+          qron_id: data.id,
+          ...body,
+        }),
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (res.ok) {
+        const d = await res.json();
+        authichainRecordId = (d as { id?: string }).id ?? null;
+      }
+    } catch (err) {
+      console.warn("[qron/register] D1 cross-reg failed:", err);
+    }
+  }
+
+  return NextResponse.json(
+    {
+      id: data.id,
+      authichain_record_id: authichainRecordId,
+      status: body.status ?? "pending_mint",
+      chain: body.chain ?? "polygon",
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/v1/os/[...slug]/route.ts
+++ b/app/api/v1/os/[...slug]/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 const SUPA = 'https://nhdnkzhtadfkkluiulhs.supabase.co/functions/v1';
 const ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5oZG5remh0YWRma2tsdWl1bGxocyIsInJlbG8iOiJhbm9uIiwiaWF0IjoxNjcyMTkzODIxNSwiZXpAIjoyMDg5NTE0MjE1fQ.akaWgxRilbjavzpsLqU149nBJqxDjbYOnRdAqrwz4J8';
 const FN_MAP: Record<string, string> = { scan: 'authichain-scan', verify: 'authichain-verify', register: 'authichain-register', events: 'authichain-events', story: 'storymode', rewards: 'qron-rewards', apikeys: 'authichain-apikeys' };
-export async function GET(req: NextRequest, { params }: { params: { slug: string[] } }) { return proxy(req, params.slug); }
-export async function POST(req: NextRequest, { params }: { params: { slug: string[] } }) { return proxy(req, params.slug); }
+export async function GET(req: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) { const { slug } = await params; return proxy(req, slug); }
+export async function POST(req: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) { const { slug } = await params; return proxy(req, slug); }
 async function proxy(req: NextRequest, slug: string[]) {
   const action = slug[0];
   const fn = FN_MAP[action];

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -23,9 +23,9 @@ function LoginContent() {
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
-    const error = searchParams.get('error')
+    const error = searchParams?.get('error')
     if (error) {
-      const message = searchParams.get('message') || 'Authentication failed. Please try again.'
+      const message = searchParams?.get('message') || 'Authentication failed. Please try again.'
       toast({ title: 'Sign-in Error', description: message, variant: 'destructive' })
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -72,7 +72,7 @@ function PricingContent() {
   const [checkoutError, setCheckoutError] = useState<string | null>(null)
   const router = useRouter()
   const params = useSearchParams()
-  const cancelled = params.get('checkout') === 'cancelled'
+  const cancelled = params?.get('checkout') === 'cancelled'
 
   async function handleCheckout(plan: typeof PLANS[0]) {
     setCheckoutError(null)

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - AuthiChain",
+  description: "AuthiChain Privacy Policy — how we collect, use, and protect your data.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <h1 className="text-3xl font-bold mb-2">Privacy Policy</h1>
+        <p className="text-muted-foreground mb-8">Effective Date: March 29, 2026</p>
+        <p className="mb-6">
+          AuthiChain (&quot;we&quot;, &quot;our&quot;, &quot;us&quot;) is committed to protecting your privacy. This
+          Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit
+          our website authichain.com, use our services, or interact with us.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">1. Information We Collect</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li><strong className="text-foreground">Personal Data:</strong> Name, email, company (from /me endpoint or sign-up).</li>
+          <li><strong className="text-foreground">Usage Data:</strong> IP address, browser type, access times, API calls (/classify, /verify).</li>
+          <li><strong className="text-foreground">Product Data:</strong> UPC/GS1 codes, images for verification (not stored long-term).</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">2. How We Use Your Information</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li>Provide verification services (AI classification, blockchain minting).</li>
+          <li>Improve services, analytics.</li>
+          <li>Comply with DSCSA (pharma), METRC (cannabis) standards where applicable.</li>
+          <li>Send updates (with opt-out).</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">3. Legal Basis (GDPR)</h2>
+        <p className="text-muted-foreground">Processing is based on contract performance, legitimate interests, or consent.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">4. Sharing Your Information</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li>Service providers (Supabase, Cloudflare).</li>
+          <li>Compliance authorities (FDA DSCSA reports if required).</li>
+          <li>No sale of personal data.</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">5. Data Retention</h2>
+        <p className="text-muted-foreground">Verification results: 30 days (KV cache); personal data: as needed for service + 1 year.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">6. Your Rights (GDPR/CCPA)</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li>Access, correct, delete, portability, object.</li>
+          <li>Contact: privacy@authichain.com</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">7. International Transfers</h2>
+        <p className="text-muted-foreground">Data processed in US/EU via Supabase/Cloudflare (SCCs in place).</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">8. Security</h2>
+        <p className="text-muted-foreground">HTTPS, API keys, encryption at rest/transit.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">9. Children&apos;s Privacy</h2>
+        <p className="text-muted-foreground">Not for under 13.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">10. Changes</h2>
+        <p className="text-muted-foreground">Updates posted here.</p>
+      </div>
+    </main>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -27,7 +27,7 @@ export default function SignupPage() {
   const [refCode, setRefCode] = useState("")
 
   useEffect(() => {
-    const ref = searchParams.get("ref")
+    const ref = searchParams?.get("ref")
     if (ref) setRefCode(ref.toUpperCase())
   }, [])
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,4 @@
-import { MetadataRoute } from "next/dist/lib/metadata/types/metadata-types";
+import type { MetadataRoute } from 'next'
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = "https://authichain.com";
   const now = new Date();
@@ -25,5 +25,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/verify`,                                         lastModified: now, changeFrequency: "weekly",  priority: 0.7 },
     { url: `${base}/pricing`,                                        lastModified: now, changeFrequency: "monthly", priority: 0.65 },
     { url: `${base}/eu-dpp`,                                         lastModified: now, changeFrequency: "monthly", priority: 0.65 },
+    { url: `${base}/privacy`, lastModified: new Date(), changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${base}/terms`, lastModified: new Date(), changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${base}/demo-video`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
   ];
 }

--- a/app/solutions/[industry]/page.tsx
+++ b/app/solutions/[industry]/page.tsx
@@ -248,8 +248,9 @@ export function generateStaticParams() {
   return Object.keys(industries).map(industry => ({ industry }))
 }
 
-export function generateMetadata({ params }: { params: { industry: string } }): Metadata {
-  const data = industries[params.industry]
+export async function generateMetadata({ params }: { params: Promise<{ industry: string }> }): Promise<Metadata> {
+  const { industry } = await params
+  const data = industries[industry]
   if (!data) return {}
   return {
     title: `${data.name} Authentication | AuthiChain`,
@@ -257,14 +258,15 @@ export function generateMetadata({ params }: { params: { industry: string } }): 
     openGraph: {
       title: `${data.name} Product Authentication | AuthiChain`,
       description: data.description,
-      url: `https://authichain.com/solutions/${params.industry}`,
+      url: `https://authichain.com/solutions/${industry}`,
     },
-    alternates: { canonical: `https://authichain.com/solutions/${params.industry}` },
+    alternates: { canonical: `https://authichain.com/solutions/${industry}` },
   }
 }
 
-export default function IndustryPage({ params }: { params: { industry: string } }) {
-  const data = industries[params.industry]
+export default async function IndustryPage({ params }: { params: Promise<{ industry: string }> }) {
+  const { industry } = await params
+  const data = industries[industry]
   if (!data) notFound()
 
   return (
@@ -392,7 +394,7 @@ export default function IndustryPage({ params }: { params: { industry: string } 
             "@type": "WebPage",
             name: `${data.name} Product Authentication | AuthiChain`,
             description: data.description,
-            url: `https://authichain.com/solutions/${params.industry}`,
+            url: `https://authichain.com/solutions/${industry}`,
             mainEntity: {
               "@type": "Product",
               name: `AuthiChain for ${data.name}`,

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - AuthiChain",
+  description: "AuthiChain Terms of Service — usage terms for our product authentication platform.",
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <h1 className="text-3xl font-bold mb-2">Terms of Service</h1>
+        <p className="text-muted-foreground mb-8">Effective Date: March 29, 2026</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">1. Acceptance</h2>
+        <p className="text-muted-foreground">Using AuthiChain (site, API) binds you to these Terms.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">2. Services</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li>AI product classification (/classify).</li>
+          <li>Blockchain verification/minting (/verify, /mintNft).</li>
+          <li>Industry compliance checks.</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">3. Accounts &amp; API Keys</h2>
+        <p className="text-muted-foreground">Secure your API key; responsible for all activity.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">4. Fees</h2>
+        <p className="text-muted-foreground">Free tier + paid plans via Stripe/RapidAPI.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">5. Prohibited Use</h2>
+        <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+          <li>No illegal/counterfeit promotion.</li>
+          <li>No excessive calls (rate limits apply).</li>
+        </ul>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">6. DSCSA/METRC Compliance</h2>
+        <p className="text-muted-foreground">For pharma/cannabis: Results aid serialization/tracking; not legal advice.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">7. Limitation of Liability</h2>
+        <p className="text-muted-foreground">No warranties; max liability = fees paid.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">8. Governing Law</h2>
+        <p className="text-muted-foreground">Michigan, US.</p>
+
+        <h2 className="text-xl font-semibold mt-8 mb-3">9. Termination</h2>
+        <p className="text-muted-foreground">We may suspend for violations.</p>
+      </div>
+    </main>
+  );
+}

--- a/app/verify/[truemark_id]/page.tsx
+++ b/app/verify/[truemark_id]/page.tsx
@@ -1,13 +1,15 @@
 import type { Metadata } from 'next';
 
-type Props = { params: { truemark_id: string } };
+type Props = { params: Promise<{ truemark_id: string }> };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  return { title: `AuthiChain - Verify ${params.truemark_id}`, description: 'Blockchain-verified product authentication' };
+  const { truemark_id } = await params;
+  return { title: `AuthiChain - Verify ${truemark_id}`, description: 'Blockchain-verified product authentication' };
 }
 
-export default function VerifyPage({ params }: Props) {
-  const url = `https://nhdnkzhtadfkkluiulhs.supabase.co/functions/v1/authichain-verify-page/${params.truemark_id}`;
+export default async function VerifyPage({ params }: Props) {
+  const { truemark_id } = await params;
+  const url = `https://nhdnkzhtadfkkluiulhs.supabase.co/functions/v1/authichain-verify-page/${truemark_id}`;
   return (
     <iframe src={url} style={{ width: '100%', height: '100vh', border: 'none' }} title="AuthiChain Verify" />
   );

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -144,7 +144,7 @@ function SearchParamsHandler({
   onAutoVerify: (id: string) => void
 }) {
   const searchParams = useSearchParams()
-  const idFromParams = searchParams.get("id") || ""
+  const idFromParams = searchParams?.get("id") || ""
 
   useEffect(() => {
     if (idFromParams) {

--- a/lib/payment-links.ts
+++ b/lib/payment-links.ts
@@ -1,0 +1,57 @@
+/**
+ * Stripe Payment Links — Authentic Economy
+ *
+ * All live payment links for QRON, AuthiChain, and StrainChain products.
+ * Reference: payment-links.html artifact
+ */
+
+export const PAYMENT_LINKS = {
+  qron: {
+    singleDesign: {
+      name: "QRON Single Design",
+      price: "$49",
+      url: "https://buy.stripe.com/aFafZh5Zf4t8dOG7nm1Nu1j",
+    },
+    brandPack: {
+      name: "QRON Brand Pack (5x)",
+      price: "$199",
+      url: "https://buy.stripe.com/6oU5kDbjz0cSeSK4ba1Nu1k",
+    },
+    enterprise: {
+      name: "QRON Enterprise",
+      price: "$999/mo",
+      url: "https://buy.stripe.com/8x2fZh73j8JofWO0YY1Nu1q",
+    },
+    credits50: {
+      name: "50 Credits",
+      price: "$9.99",
+      url: "https://buy.stripe.com/3cIaEX73jcZE5ia2321Nu1l",
+    },
+    credits250: {
+      name: "250 Credits",
+      price: "$39.99",
+      url: "https://buy.stripe.com/9B69AT73j9NseSKazy1Nu1m",
+    },
+    credits1000: {
+      name: "1000 Credits",
+      price: "$99.99",
+      url: "https://buy.stripe.com/9B600j73jcZE6megXW1Nu1n",
+    },
+  },
+  authichain: {
+    starter: {
+      name: "AuthiChain Starter",
+      price: "$299/mo",
+      url: "https://buy.stripe.com/28E8wP0EVf7M6mefTS1Nu1p",
+    },
+  },
+  strainchain: {
+    basic: {
+      name: "StrainChain Basic",
+      price: "$199/mo",
+      url: "https://buy.stripe.com/9B6cN59br5xcaCuazy1Nu1o",
+    },
+  },
+} as const;
+
+export type PaymentLinkKey = keyof typeof PAYMENT_LINKS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "authichain",
       "version": "1.0.0",
       "dependencies": {
+        "@fal-ai/client": "^1.9.5",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.4",
         "@radix-ui/react-alert-dialog": "^1.1.7",
@@ -2069,7 +2070,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3817,6 +3817,20 @@
         "@ethersproject/strings": "^5.8.0"
       }
     },
+    "node_modules/@fal-ai/client": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@fal-ai/client/-/client-1.9.5.tgz",
+      "integrity": "sha512-knCMOqXapzL5Lsp4Xh/B/VfvbseKgHg2Kt//MjcxN5weF59/26En3zXTPd8pljl4QAr7b62X5EuNCT69MpyjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^3.0.0-beta2",
+        "eventsource-parser": "^1.1.2",
+        "robot3": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
@@ -3917,7 +3931,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3940,7 +3953,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3963,7 +3975,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3980,7 +3991,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3997,7 +4007,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4014,7 +4023,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4031,7 +4039,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4048,7 +4055,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4065,7 +4071,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4082,7 +4087,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4099,7 +4103,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4116,7 +4119,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4133,7 +4135,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4156,7 +4157,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4179,7 +4179,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4202,7 +4201,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4225,7 +4223,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4248,7 +4245,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4271,7 +4267,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4294,7 +4289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4317,7 +4311,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4337,7 +4330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4357,7 +4349,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4377,7 +4368,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -15234,6 +15224,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -19661,6 +19660,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robot3": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/robot3/-/robot3-0.4.1.tgz",
+      "integrity": "sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/router": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": "20.x"
   },
   "dependencies": {
+    "@fal-ai/client": "^1.9.5",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.4",
     "@radix-ui/react-alert-dialog": "^1.1.7",

--- a/packages/characters/src/prompt.ts
+++ b/packages/characters/src/prompt.ts
@@ -1,0 +1,80 @@
+export type Archetype =
+  | 'Guardian'
+  | 'Archivist'
+  | 'Sentinel'
+  | 'Scout'
+  | 'Arbiter'
+  | 'Merchant'
+  | 'Explorer';
+
+export interface CharacterPromptInput {
+  archetype: Archetype;
+  roleSummary?: string;
+  colorway?: string;
+  mood?: string;
+  objectContext?: string;
+  brandContext?: string;
+  style?: string;
+}
+
+export interface BuiltPrompt {
+  prompt: string;
+  negativePrompt: string;
+}
+
+const DEFAULT_ROLE_SUMMARY: Record<Archetype, string> = {
+  Guardian: 'protects authenticity and shields verified value',
+  Archivist: 'records provenance, origin, and historical truth',
+  Sentinel: 'watches for anomalies, counterfeit signals, and network abuse',
+  Scout: 'discovers objects, listings, and verification opportunities',
+  Arbiter: 'judges conflicting signals and helps finalize consensus',
+  Merchant: 'represents trusted trade, verified ownership, and value exchange',
+  Explorer: 'unlocks engagement through scans, discovery, and movement across the network'
+};
+
+export function buildOpenArtPrompt(input: CharacterPromptInput): BuiltPrompt {
+  const roleSummary = input.roleSummary ?? DEFAULT_ROLE_SUMMARY[input.archetype];
+  const colorway = input.colorway ?? 'graphite black, polished silver, neon blue, restrained gold accents';
+  const mood = input.mood ?? 'confident, intelligent, premium, trustworthy';
+  const objectContext = input.objectContext ?? 'general high-value authenticated objects';
+  const brandContext = input.brandContext ?? 'AuthiChain, a proof-of-authenticity protocol where truth has tradeable value';
+  const style = input.style ?? 'premium futuristic heraldic concept art';
+
+  const prompt = `Create an AuthiCharacter for AuthiChain.
+
+Archetype: ${input.archetype}
+Role: ${roleSummary}
+Colorway: ${colorway}
+Mood: ${mood}
+Object context: ${objectContext}
+Brand context: ${brandContext}
+Style: ${style}
+
+Visual direction:
+A premium futuristic heraldic character representing ${input.archetype} within a proof-of-authenticity network. The design must express verification, trust, provenance, protection, intelligence, and digital value. Strong silhouette, iconic chest insignia, elegant material rendering, clean composition, and mint-worthy detail. High-end concept art quality. Suitable for collectible identity, protocol badge, dashboard avatar, and AI verification agent persona.
+
+Composition requirements:
+centered portrait, high face-or-helmet clarity, premium materials, subtle luminous accents, restrained background, cinematic studio lighting, no text, no watermark, highly readable at thumbnail size.
+
+Output requirements:
+high resolution, vertical portrait, polished finish, premium contrast, mint-ready, no background clutter.`;
+
+  const negativePrompt = [
+    'low quality',
+    'blurry',
+    'muddy contrast',
+    'cluttered background',
+    'text',
+    'watermark',
+    'duplicate limbs',
+    'bad hands',
+    'deformed anatomy',
+    'generic fantasy',
+    'childish mascot',
+    'goofy meme energy',
+    'over-sexualized styling',
+    'noisy composition'
+  ].join(', ');
+
+  return { prompt, negativePrompt };
+}

--- a/packages/openart/src/client.ts
+++ b/packages/openart/src/client.ts
@@ -1,0 +1,65 @@
+export interface OpenArtGenerateRequest {
+  prompt: string;
+  negativePrompt?: string;
+  numImages?: number;
+  size?: '1024x1024' | '1024x1536' | '1536x1024';
+  transparentBackground?: boolean;
+  model?: string;
+}
+
+export interface OpenArtGeneratedAsset {
+  id: string;
+  imageUrl: string;
+  previewUrl?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OpenArtGenerateResponse {
+  requestId: string;
+  assets: OpenArtGeneratedAsset[];
+  raw: unknown;
+}
+
+export class OpenArtClient {
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string = 'https://openart-api.example.com/v1'
+  ) {}
+
+  async generate(req: OpenArtGenerateRequest): Promise<OpenArtGenerateResponse> {
+    const response = await fetch(`${this.baseUrl}/images/generations`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({
+        prompt: req.prompt,
+        negative_prompt: req.negativePrompt,
+        num_images: req.numImages ?? 4,
+        size: req.size ?? '1024x1536',
+        transparent_background: req.transparentBackground ?? false,
+        model: req.model ?? 'openart-default'
+      })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`OpenArt generate failed: ${response.status} ${text}`);
+    }
+
+    const raw = await response.json();
+    const assets: OpenArtGeneratedAsset[] = (raw.data?.images ?? raw.images ?? []).map((img: any, idx: number) => ({
+      id: img.id ?? `${raw.id ?? 'gen'}-${idx}`,
+      imageUrl: img.url ?? img.image_url,
+      previewUrl: img.preview_url ?? img.thumbnail_url,
+      metadata: img
+    }));
+
+    return {
+      requestId: raw.id ?? crypto.randomUUID(),
+      assets,
+      raw
+    };
+  }
+}

--- a/workers/authichain-automation/index.js
+++ b/workers/authichain-automation/index.js
@@ -1,0 +1,468 @@
+export const dynamic = 'force-dynamic';
+// ============================================================
+// AuthiChain Automation Worker — v2.0.2
+//
+// Fix: Removed `instanceof D1Database` checks that crash because
+// D1Database is not a global in Workers runtime (ReferenceError → 1101)
+// ============================================================
+
+function logger(eventType, data) {
+  console.log(`[${eventType}]`, JSON.stringify(data));
+}
+
+function corsHeaders(origin = "*") {
+  return {
+    "Access-Control-Allow-Origin": origin || "*",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, Stripe-Signature",
+    "Access-Control-Max-Age": "86400"
+  };
+}
+
+function jsonResponse(data, status = 200, origin) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders(origin) }
+  });
+}
+
+function successResponse(data, message, origin) {
+  return jsonResponse({ success: true, data, message }, 200, origin);
+}
+
+function errorResponse(error, status = 400, origin) {
+  return jsonResponse({ success: false, error }, status, origin);
+}
+
+function handleOptions(origin) {
+  return new Response(null, { status: 204, headers: corsHeaders(origin) });
+}
+
+async function verifyStripeSignature(body, signature, webhookSecret) {
+  if (!signature || !webhookSecret) return false;
+  try {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey("raw", encoder.encode(webhookSecret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+    const signatureBytes = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+    const expected = `sha256=${Array.from(new Uint8Array(signatureBytes)).map((b) => b.toString(16).padStart(2, "0")).join("")}`;
+    return signature === expected;
+  } catch (error) {
+    logger("stripe_verify", { error: error.message });
+    return false;
+  }
+}
+
+// ── DB operations ─────────────────────────────────────────────
+async function getAllManufacturers(db) {
+  const result = await db.prepare("SELECT * FROM manufacturers ORDER BY onboarded_at DESC").all();
+  return result.results;
+}
+
+async function getManufacturerById(db, id) {
+  return db.prepare("SELECT * FROM manufacturers WHERE id = ?").bind(id).first();
+}
+
+async function getManufacturerByEmail(db, email) {
+  return db.prepare("SELECT * FROM manufacturers WHERE contact_email = ?").bind(email).first();
+}
+
+async function createManufacturer(db, data) {
+  const id = `mfr_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const tier = data.tier || "free";
+  await db.prepare("INSERT INTO manufacturers (id, company_name, contact_email, tier) VALUES (?, ?, ?, ?)")
+    .bind(id, data.company_name, data.contact_email, tier).run();
+  return getManufacturerById(db, id);
+}
+
+async function updateManufacturerTier(db, id, tier) {
+  await db.prepare("UPDATE manufacturers SET tier = ? WHERE id = ?").bind(tier, id).run();
+  return getManufacturerById(db, id);
+}
+
+async function getAllDeals(db) {
+  const result = await db.prepare("SELECT * FROM deals ORDER BY created_at DESC").all();
+  return result.results;
+}
+
+async function getDealsByManufacturer(db, manufacturerId) {
+  const result = await db.prepare("SELECT * FROM deals WHERE manufacturer_id = ? ORDER BY created_at DESC").bind(manufacturerId).all();
+  return result.results;
+}
+
+async function createDeal(db, data) {
+  const id = `deal_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  await db.prepare("INSERT INTO deals (id, manufacturer_id, deal_name, deal_value, stage, owner_email) VALUES (?, ?, ?, ?, ?, ?)")
+    .bind(id, data.manufacturer_id, data.deal_name, data.deal_value, data.stage, data.owner_email).run();
+  return db.prepare("SELECT * FROM deals WHERE id = ?").bind(id).first();
+}
+
+async function updateDealStage(db, id, stage) {
+  await db.prepare("UPDATE deals SET stage = ? WHERE id = ?").bind(stage, id).run();
+  return db.prepare("SELECT * FROM deals WHERE id = ?").bind(id).first();
+}
+
+async function getAllSubscriptions(db) {
+  const result = await db.prepare("SELECT * FROM subscriptions ORDER BY created_at DESC").all();
+  return result.results;
+}
+
+async function getSubscriptionsByManufacturer(db, manufacturerId) {
+  const result = await db.prepare("SELECT * FROM subscriptions WHERE manufacturer_id = ? ORDER BY created_at DESC").bind(manufacturerId).all();
+  return result.results;
+}
+
+async function createSubscription(db, data) {
+  const id = `sub_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  await db.prepare("INSERT INTO subscriptions (id, manufacturer_id, plan_name, amount, status) VALUES (?, ?, ?, ?, ?)")
+    .bind(id, data.manufacturer_id, data.plan_name, data.amount, data.status).run();
+  return db.prepare("SELECT * FROM subscriptions WHERE id = ?").bind(id).first();
+}
+
+async function updateSubscriptionStatus(db, id, status) {
+  await db.prepare("UPDATE subscriptions SET status = ? WHERE id = ?").bind(status, id).run();
+  return db.prepare("SELECT * FROM subscriptions WHERE id = ?").bind(id).first();
+}
+
+async function getAllNFTMints(db, limit = 100) {
+  const result = await db.prepare("SELECT * FROM nft_mints ORDER BY timestamp DESC LIMIT ?").bind(limit).all();
+  return result.results;
+}
+
+async function getNFTMintByTxHash(db, txHash) {
+  return db.prepare("SELECT * FROM nft_mints WHERE tx_hash = ?").bind(txHash).first();
+}
+
+async function recordNFTMint(db, data) {
+  const existing = await getNFTMintByTxHash(db, data.tx_hash);
+  if (existing) return existing;
+  await db.prepare("INSERT INTO nft_mints (token_id, to_address, tx_hash, block_number, timestamp) VALUES (?, ?, ?, ?, ?)")
+    .bind(data.token_id, data.to_address, data.tx_hash, data.block_number, data.timestamp).run();
+  return getNFTMintByTxHash(db, data.tx_hash);
+}
+
+async function getAnalytics(db) {
+  const [manufacturers, deals, subscriptions, nfts] = await Promise.all([
+    db.prepare("SELECT COUNT(*) as count FROM manufacturers").first(),
+    db.prepare("SELECT COUNT(*) as count, SUM(deal_value) as total_value FROM deals").first(),
+    db.prepare("SELECT COUNT(*) as count, SUM(amount) as mrr FROM subscriptions WHERE status = ?").bind("active").first(),
+    db.prepare("SELECT COUNT(*) as count FROM nft_mints").first()
+  ]);
+  return {
+    manufacturers: manufacturers?.count || 0,
+    deals: { count: deals?.count || 0, total_value: deals?.total_value || 0 },
+    subscriptions: { count: subscriptions?.count || 0, mrr: subscriptions?.mrr || 0 },
+    nfts: { count: nfts?.count || 0 }
+  };
+}
+
+// ── Pricing ─────────────────────────────────────────────────────
+async function handlePricing(request, env) {
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured", 503, origin);
+  try {
+    const result = await env.DB.prepare("SELECT * FROM tier_config ORDER BY monthly_price ASC").all();
+    const tiers = result.results.map(t => ({
+      ...t,
+      features: (() => { try { return JSON.parse(t.features || "[]"); } catch { return []; } })()
+    }));
+    return successResponse(tiers, undefined, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+// ── Stripe webhook ────────────────────────────────────────────
+const PRICE_TO_TIER = {
+  "price_1StuAZGqTruSqV8TcoSJj4kr": "starter",
+  "price_1StuAeGqTruSqV8TbERZ2LMU": "growth",
+  "price_1StuAiGqTruSqV8ToXJM469E": "scale",
+  "price_1StuAmGqTruSqV8Tj6UHDhCm": "enterprise",
+  "price_1SxWtmGqTruSqV8T7U95QG9O": "starter",
+  "price_1SxWvxGqTruSqV8T7U95QG9O": "growth",
+  "price_1Sz7dTGqTruSqV8TnicpSP5w": "starter"
+};
+
+async function logAutomation(db, eventType, payload, result, status) {
+  try {
+    await db.prepare("INSERT INTO automation_logs (event_type, payload, result, status, created_at) VALUES (?, ?, ?, ?, datetime('now'))")
+      .bind(eventType, JSON.stringify(payload), JSON.stringify(result), status).run();
+  } catch (e) { console.error("Failed to write automation log:", e); }
+}
+
+async function handleStripeWebhook(request, env) {
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured", 503, origin);
+
+  let event;
+  try {
+    const body = await request.text();
+    const signature = request.headers.get("stripe-signature");
+    if (env.STRIPE_WEBHOOK_SECRET && signature) {
+      const isValid = await verifyStripeSignature(body, signature, env.STRIPE_WEBHOOK_SECRET);
+      if (!isValid) return errorResponse("Invalid webhook signature", 401, origin);
+    }
+    event = JSON.parse(body);
+  } catch (e) {
+    return errorResponse("Invalid JSON body", 400, origin);
+  }
+
+  const eventType = event.type;
+  logger("stripe_webhook", { event_type: eventType });
+
+  try {
+    if (eventType === "customer.subscription.created" || eventType === "customer.subscription.updated") {
+      const subscription = event.data.object;
+      const customerEmail = event.data.object.customer_email || (subscription.customer ? `stripe_${subscription.customer}` : null);
+      const priceId = subscription.items?.data?.[0]?.price?.id;
+      const tier = PRICE_TO_TIER[priceId] || "starter";
+      const stripePriceAmount = subscription.items?.data?.[0]?.price?.unit_amount || 0;
+
+      let manufacturer = customerEmail ? await getManufacturerByEmail(env.DB, customerEmail) : null;
+      if (!manufacturer) {
+        manufacturer = await createManufacturer(env.DB, {
+          company_name: customerEmail ? customerEmail.split("@")[0] : `customer_${subscription.customer}`,
+          contact_email: customerEmail || `${subscription.customer}@stripe.auto`,
+          tier
+        });
+      } else {
+        manufacturer = await updateManufacturerTier(env.DB, manufacturer.id, tier);
+      }
+
+      await createSubscription(env.DB, {
+        manufacturer_id: manufacturer.id,
+        plan_name: tier,
+        amount: stripePriceAmount / 100,
+        status: subscription.status === "active" ? "active" : "pending"
+      });
+
+      await env.DB.prepare("INSERT OR REPLACE INTO manufacturer_stripe (manufacturer_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, updated_at) VALUES (?, ?, ?, ?, datetime('now'))")
+        .bind(manufacturer.id, subscription.customer, subscription.id, priceId || "").run();
+
+      await logAutomation(env.DB, eventType, { subscription_id: subscription.id, tier, email: customerEmail }, { manufacturer_id: manufacturer.id }, "success");
+      return successResponse({ manufacturer_id: manufacturer.id, tier, action: "onboarded" }, undefined, origin);
+    }
+
+    if (eventType === "customer.subscription.deleted") {
+      const subscription = event.data.object;
+      const row = await env.DB.prepare("SELECT * FROM manufacturer_stripe WHERE stripe_subscription_id = ?").bind(subscription.id).first();
+      if (row) {
+        await updateManufacturerTier(env.DB, row.manufacturer_id, "free");
+        await env.DB.prepare("UPDATE subscriptions SET status = 'cancelled' WHERE manufacturer_id = ? AND status = 'active'").bind(row.manufacturer_id).run();
+        await logAutomation(env.DB, eventType, { subscription_id: subscription.id }, { manufacturer_id: row.manufacturer_id, downgraded_to: "free" }, "success");
+      }
+      return successResponse({ handled: true, event: eventType }, undefined, origin);
+    }
+
+    return successResponse({ handled: false, event: eventType }, undefined, origin);
+  } catch (error) {
+    await logAutomation(env.DB, eventType, event.data?.object, { error: error.message }, "error").catch(() => {});
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+// ── Route handlers ──────────────────────────────────────────────
+async function handleManufacturers(request, env) {
+  const url = new URL(request.url);
+  const method = request.method;
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured.", 503, origin);
+  try {
+    if (method === "GET") {
+      const id = url.pathname.split("/").pop();
+      if (id && id !== "manufacturers") {
+        const manufacturer = await getManufacturerById(env.DB, id);
+        if (!manufacturer) return errorResponse("Manufacturer not found", 404, origin);
+        return successResponse(manufacturer, undefined, origin);
+      }
+      return successResponse(await getAllManufacturers(env.DB), undefined, origin);
+    }
+    if (method === "POST") {
+      const body = await request.json();
+      if (!body.company_name || !body.contact_email) return errorResponse("Missing required fields", 400, origin);
+      return successResponse(await createManufacturer(env.DB, body), "Manufacturer created successfully", origin);
+    }
+    if (method === "PUT") {
+      const id = url.pathname.split("/").pop();
+      if (!id || id === "manufacturers") return errorResponse("Manufacturer ID required", 400, origin);
+      const body = await request.json();
+      if (!body.tier) return errorResponse("Missing required field: tier", 400, origin);
+      return successResponse(await updateManufacturerTier(env.DB, id, body.tier), "Manufacturer updated successfully", origin);
+    }
+    return errorResponse("Method not allowed", 405, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+async function handleDeals(request, env) {
+  const url = new URL(request.url);
+  const method = request.method;
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured.", 503, origin);
+  try {
+    if (method === "GET") {
+      const manufacturerId = url.searchParams.get("manufacturer_id");
+      if (manufacturerId) return successResponse(await getDealsByManufacturer(env.DB, manufacturerId), undefined, origin);
+      return successResponse(await getAllDeals(env.DB), undefined, origin);
+    }
+    if (method === "POST") {
+      const body = await request.json();
+      if (!body.manufacturer_id || !body.deal_name || !body.deal_value || !body.stage || !body.owner_email)
+        return errorResponse("Missing required fields", 400, origin);
+      return successResponse(await createDeal(env.DB, body), "Deal created successfully", origin);
+    }
+    if (method === "PUT") {
+      const id = url.pathname.split("/").pop();
+      if (!id || id === "deals") return errorResponse("Deal ID required", 400, origin);
+      const body = await request.json();
+      if (!body.stage) return errorResponse("Missing required field: stage", 400, origin);
+      return successResponse(await updateDealStage(env.DB, id, body.stage), "Deal updated successfully", origin);
+    }
+    return errorResponse("Method not allowed", 405, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+async function handleSubscriptions(request, env) {
+  const url = new URL(request.url);
+  const method = request.method;
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured.", 503, origin);
+  try {
+    if (method === "GET") {
+      const manufacturerId = url.searchParams.get("manufacturer_id");
+      if (manufacturerId) return successResponse(await getSubscriptionsByManufacturer(env.DB, manufacturerId), undefined, origin);
+      return successResponse(await getAllSubscriptions(env.DB), undefined, origin);
+    }
+    if (method === "POST") {
+      const body = await request.json();
+      if (!body.manufacturer_id || !body.plan_name || !body.amount || !body.status)
+        return errorResponse("Missing required fields", 400, origin);
+      return successResponse(await createSubscription(env.DB, body), "Subscription created successfully", origin);
+    }
+    if (method === "PUT") {
+      const id = url.pathname.split("/").pop();
+      if (!id || id === "subscriptions") return errorResponse("Subscription ID required", 400, origin);
+      const body = await request.json();
+      if (!body.status) return errorResponse("Missing required field: status", 400, origin);
+      return successResponse(await updateSubscriptionStatus(env.DB, id, body.status), "Subscription updated successfully", origin);
+    }
+    return errorResponse("Method not allowed", 405, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+async function handleNFTs(request, env) {
+  const url = new URL(request.url);
+  const method = request.method;
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured.", 503, origin);
+  try {
+    if (method === "GET") {
+      const limit = parseInt(url.searchParams.get("limit") || "100");
+      return successResponse(await getAllNFTMints(env.DB, limit), undefined, origin);
+    }
+    if (method === "POST") {
+      const body = await request.json();
+      if (!body.token_id || !body.to_address || !body.tx_hash || !body.block_number || !body.timestamp)
+        return errorResponse("Missing required fields", 400, origin);
+      return successResponse(await recordNFTMint(env.DB, body), "NFT mint recorded successfully", origin);
+    }
+    return errorResponse("Method not allowed", 405, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+async function handleAnalyticsRoute(request, env) {
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+  if (!env.DB) return errorResponse("Database not configured.", 503, origin);
+  try {
+    if (request.method === "GET") return successResponse(await getAnalytics(env.DB), undefined, origin);
+    return errorResponse("Method not allowed", 405, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+// ── Rate limiter Durable Object ───────────────────────────────
+var RateLimiter = class {
+  constructor(state) { this.state = state; }
+  async fetch(request) {
+    const url = new URL(request.url);
+    const clientId = url.searchParams.get("clientId") || "anonymous";
+    const limit = parseInt(url.searchParams.get("limit") || "100");
+    const windowMs = parseInt(url.searchParams.get("windowMs") || "60000");
+    const now = Date.now();
+    let state = await this.state.storage.get(clientId);
+    if (!state || now > state.resetTime) state = { requests: 0, resetTime: now + windowMs };
+    if (state.requests >= limit) {
+      const remaining = Math.ceil((state.resetTime - now) / 1e3);
+      return new Response(JSON.stringify({ allowed: false, limit, remaining: 0, resetIn: remaining }), {
+        status: 429, headers: { "Content-Type": "application/json", "Retry-After": remaining.toString() }
+      });
+    }
+    state.requests++;
+    await this.state.storage.put(clientId, state);
+    return new Response(JSON.stringify({ allowed: true, limit, remaining: limit - state.requests, resetIn: Math.ceil((state.resetTime - now) / 1e3) }), {
+      status: 200, headers: { "Content-Type": "application/json" }
+    });
+  }
+};
+
+async function checkRateLimit(request, env) {
+  if (!env.RATE_LIMITER) return null;
+  const clientId = request.headers.get("CF-Connecting-IP") || "anonymous";
+  const id = env.RATE_LIMITER.idFromName(clientId);
+  const stub = env.RATE_LIMITER.get(id);
+  const rateLimitUrl = new URL(request.url);
+  rateLimitUrl.searchParams.set("clientId", clientId);
+  rateLimitUrl.searchParams.set("limit", "100");
+  rateLimitUrl.searchParams.set("windowMs", "60000");
+  const resp = await stub.fetch(new Request(rateLimitUrl.toString()));
+  if (resp.status === 429) return resp;
+  return null;
+}
+
+// ── Main router ───────────────────────────────────────────────
+async function handleRequest(request, env) {
+  const url = new URL(request.url);
+  const path = url.pathname;
+  const origin = request.headers.get("Origin") || env.ALLOWED_ORIGINS || "*";
+
+  if (request.method === "OPTIONS") return handleOptions(origin);
+  if (request.method !== "GET") {
+    const rateLimitResponse = await checkRateLimit(request, env);
+    if (rateLimitResponse) return rateLimitResponse;
+  }
+
+  try {
+    if (path === "/" || path === "/health") {
+      return successResponse({
+        status: "healthy",
+        environment: env.ENVIRONMENT,
+        timestamp: new Date().toISOString(),
+        version: "2.0.2",
+        endpoints: ["/pricing", "/analytics", "/manufacturers", "/deals", "/subscriptions", "/nfts", "/webhooks/stripe"]
+      }, undefined, origin);
+    }
+    if (path === "/analytics") return handleAnalyticsRoute(request, env);
+    if (path === "/pricing") return handlePricing(request, env);
+    if (path === "/webhooks/stripe") return handleStripeWebhook(request, env);
+    if (path.startsWith("/manufacturers")) return handleManufacturers(request, env);
+    if (path.startsWith("/deals")) return handleDeals(request, env);
+    if (path.startsWith("/subscriptions")) return handleSubscriptions(request, env);
+    if (path.startsWith("/nfts")) return handleNFTs(request, env);
+    return errorResponse("Endpoint not found", 404, origin);
+  } catch (error) {
+    return errorResponse(error.message, 500, origin);
+  }
+}
+
+export { RateLimiter };
+export default {
+  async fetch(request, env) { return handleRequest(request, env); },
+  async scheduled(event, env) { console.log("Cron trigger fired at:", new Date(event.scheduledTime).toISOString()); }
+};

--- a/workers/authichain-automation/wrangler.toml
+++ b/workers/authichain-automation/wrangler.toml
@@ -1,0 +1,20 @@
+name = "authichain-automation"
+main = "index.js"
+compatibility_date = "2024-09-23"
+
+[vars]
+ENVIRONMENT = "production"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "authichain-db"
+database_id = "ebd8081b-ac13-485a-8b0e-a6cd9c0f7be5"
+
+[durable_objects]
+bindings = [
+  { name = "RATE_LIMITER", class_name = "RateLimiter" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["RateLimiter"]


### PR DESCRIPTION
## Summary

- **10 new files**: privacy page, terms page, demo-video walkthrough, QRON generate/register routes, AuthiCharacter generate/select routes, character prompt builder, OpenArt client, payment links config, authichain-automation worker (v2.0.2 fix)
- **13 files fixed**: Next.js 15 async params migration (6 routes), searchParams null safety (5 pages), non-route export removal, sitemap import fix
- **Worker deploy job** added for authichain-automation

## Pre-existing issues fixed

| Issue | Fix |
|-------|-----|
| `class` instead of `className` in layout.tsx | Changed to `className` |
| OpenAI module-scope init crashes build | Lazy init via `getOpenAI()` |
| Next.js 15 async params (`Promise<>`) | 6 dynamic routes migrated |
| `searchParams` possibly null | Optional chaining in 5 components |
| Non-route export from route file | Removed `export` keyword |
| Worker 500 on /analytics | Removed `instanceof D1Database` check |
| Broken sitemap import | Fixed to `import type { MetadataRoute } from 'next'` |

## Verification

- TypeScript: **0 errors** (was 8+)
- Next.js build: **0 errors, 98 static pages** (was failing)
- D1 `qron_registrations` table + 3 indexes created

## Test plan

- [ ] Verify /privacy and /terms pages render
- [ ] Verify /demo-video walkthrough plays
- [ ] Verify TypeScript still compiles clean
- [ ] Verify build passes on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)