### PR TITLE
fix: use --config wrangler.toml in automation deploy job

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -120,5 +120,5 @@ jobs:
       - name: Install Wrangler
         run: npm install --no-save wrangler || npm install -g wrangler
       - name: Deploy
-        run: npx wrangler deploy
+        run: npx wrangler deploy --config wrangler.toml
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Fixes authichain-automation deploy job picking up root `wrangler.jsonc` instead of `workers/authichain-automation/wrangler.toml`
- Root config points to `.open-next/worker.js` (Next.js Cloudflare adapter), causing worker deploy to fail with "entry-point file not found"

## Test plan

- [ ] Merge and verify Deploy Cloudflare Workers action succeeds for authichain-automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)